### PR TITLE
Fix buyer profile update

### DIFF
--- a/Server/Controllers/UserApiController.cs
+++ b/Server/Controllers/UserApiController.cs
@@ -27,6 +27,35 @@ namespace Server.Controllers
         }
 
         /// <summary>
+        /// Gets a user by their ID.
+        /// </summary>
+        /// <param name="userId">The ID of the user.</param>
+        /// <returns>An ActionResult containing the user if found, otherwise appropriate error status.</returns>
+        [HttpGet("{userId}")]
+        [ProducesResponseType(typeof(User), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(string), StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult<User?>> GetUserById(int userId)
+        {
+            if (userId <= 0)
+            {
+                return this.BadRequest("User ID must be a positive integer.");
+            }
+
+            try
+            {
+                User? user = await this.userRepository.GetUserById(userId);
+
+                return this.Ok(user);
+            }
+            catch (Exception)
+            {
+                // Return a 500 Internal Server Error
+                return this.StatusCode(StatusCodes.Status500InternalServerError, "An error occurred while getting user by ID.");
+            }
+        }
+
+        /// <summary>
         /// Gets a user by their email address.
         /// </summary>
         /// <param name="email">The email address of the user.</param>

--- a/Server/Repository/UserRepository.cs
+++ b/Server/Repository/UserRepository.cs
@@ -59,6 +59,16 @@ namespace Server.Repository
         }
 
         /// <summary>
+        /// Retrieves a user from the database by their ID.
+        /// </summary>
+        /// <param name="id">The ID of the user.</param>
+        /// <returns>A <see cref="Task{User?}"/> representing the result of the asynchronous operation, with a result of the user if found, or null if not found.</returns>
+        public async Task<User?> GetUserById(int id)
+        {
+            return await this.dbContext.Users.FirstOrDefaultAsync(user => user.UserId == id);
+        }
+
+        /// <summary>
         /// Retrieves a user from the database by their username. If no user is found, returns null.
         /// </summary>
         /// <param name="username">The username of the user that we search for.</param>

--- a/SharedClassLibrary/IRepository/IUserRepository.cs
+++ b/SharedClassLibrary/IRepository/IUserRepository.cs
@@ -23,6 +23,13 @@ namespace SharedClassLibrary.IRepository
         Task AddUser(User user);
 
         /// <summary>
+        /// Returns a user form the database by their id. If no user is found, returns null.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        Task<User?> GetUserById(int id);
+
+        /// <summary>
         /// Retrieves a user from the database by their username. If no user is found, returns null.
         /// </summary>
         /// <param name="username">The username of the user that we search for.</param>

--- a/SharedClassLibrary/ProxyRepository/UserProxyRepository.cs
+++ b/SharedClassLibrary/ProxyRepository/UserProxyRepository.cs
@@ -40,6 +40,22 @@ namespace SharedClassLibrary.ProxyRepository
         }
 
         /// <inheritdoc />
+        public async Task<User?> GetUserById(int userId)
+        {
+            var response = await this.httpClient.GetAsync($"{ApiBaseRoute}/{userId}");
+            await this.ThrowOnError(nameof(GetUserById), response);
+
+            // Check if the response content is empty
+            if (response.Content.Headers.ContentLength == 0)
+            {
+                return null; // No content means no user
+            }
+
+            var user = await response.Content.ReadFromJsonAsync<User>();
+            return user;
+        }
+
+        /// <inheritdoc />
         public async Task<bool> EmailExists(string email)
         {
             var response = await this.httpClient.GetAsync($"{ApiBaseRoute}/email-exists?email={email}");

--- a/SharedClassLibrary/Service/BuyerService.cs
+++ b/SharedClassLibrary/Service/BuyerService.cs
@@ -74,7 +74,8 @@ namespace SharedClassLibrary.Service
         public async Task<Buyer> GetBuyerByUser(User user)
         {
             var buyer = new Buyer();
-            buyer.User = user;
+            User? dbUser = await this.userRepo.GetUserById(user.UserId);
+            buyer.User = dbUser; // this can be null but it will not be, very unlikely
             await this.LoadBuyer(buyer, BuyerDataSegments.BasicInfo | BuyerDataSegments.Wishlist | BuyerDataSegments.Linkages);
             return buyer;
         }


### PR DESCRIPTION
fix: buyer update now fixed, works as expected, user with no password/username initiated that was the problem, so I added a method in which a user can be loaded from the ID since there was none existent

NOTE: There is still an issue when the address updates, the shipping address points to the same object as the billing address even though the use same address is NOT checked, I tried to solve it but I did not manage to do it. The issue is not that important tho.